### PR TITLE
非同期通信の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,53 @@
+$(function() {
+
+
+  function buildMessage(message){
+    var image = ""
+    message.image ? image = `<img src="${message.image}">` : image = ""
+
+    var html = `<div class="message">
+                  <div class="message__upper-info">
+                  <div class="message__upper-info__talker">
+                    ${message.user.name}
+                  </div>
+                  <div class="message__upper-info__date">
+                    ${message.created_at}
+                  </div>
+                  </div>
+                  <div class="message__text">
+                  <p class="message__text__content">
+                    ${message.content}
+                  </p>
+                    ${image}
+                  </div>
+                </div>`
+    return html;
+  }
+
+
+  $('.form').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(document.getElementById("new_message"));
+    var url = $(document.getElementById("new_message")).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(message){
+      var html = buildMessage(message);
+      $('.messages').append(html);
+      $('.messages').animate({scrollTop : $('.messages')[0].scrollHeight});
+      scroll();
+      $('form')[0].reset();
+      $('.submit-btn').removeAttr('disabled')
+    })
+    .fail(function(){
+      alert('メッセージを入力してください');
+      $('.submit-btn').removeAttr('disabled')
+    })
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,11 +9,14 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      flash.now[:notice] = 'メッセージが送信されました'
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = "メッセージを入力してください。"
-      render :index
+    end
+    respond_to do |format|
+      format.html { redirect_to group_messages_path(@group) }
+      format.json
     end
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,4 +5,8 @@ class Message < ApplicationRecord
   validates :content, presence: true, unless: :image?
 
   mount_uploader :image, ImageUploader
+
+  def created_at
+    attributes['created_at'].strftime("%Y/%m/%d(%a) %H:%M:%S")
+  end
 end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user @message.user
+json.content @message.content 
+json.image @message.image.thumb.url
+json.created_at @message.created_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
       g.test_framework false
       config.i18n.default_locale = :ja
     end
+    config.time_zone = 'Asia/Tokyo'
   end
 end


### PR DESCRIPTION
# What
メッセージ送信機能に非同期通信を実装した。

- Controllerからhtmlをレスポンスとするコードを削除しても問題なく動作する
- 画面がリロードせずに投稿できている
- テキストのみ/画像のみ/画像とテキスト、それぞれでエラーが出ずに投稿ができる
- 連続での投稿が可能
- 投稿と同時に最下部までスクロールする
- 日時表記の変更
- SENDボタンを連打したら適切なアラートが表示される
- 一度リロードしなくても、正常に非同期投稿ができるか

# Why
ChatSpaceのメイン機能であるメッセージ送信を、ページ遷移なしでよりスムーズに行うため。


![](https://i.gyazo.com/9b63e881173b8db0438c0638a871da5c.png)
