### PR TITLE
非同期投稿の修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,4 @@
-$(function() {
+$(document).on('turbolinks:load', function(){
 
   function buildMessage(message){
     var image = ""
@@ -21,7 +21,7 @@ $(function() {
                   </div>
                 </div>`
     return html;
-  }
+  } 
 
 
   $('.form').on('submit', function(e){


### PR DESCRIPTION
# What
テキストの非同期投稿で、グループを開いた最初の投稿時のみ、自動でリロードがかかるエラーを修正。

 # Why
非同期投稿の機能は、グループを開いた初回から実装されるべきであるため。